### PR TITLE
Add support for currency conversion in currencies that do not use fractional units (JPY)

### DIFF
--- a/lib/paypal-sdk/adaptive_payments/data_types.rb
+++ b/lib/paypal-sdk/adaptive_payments/data_types.rb
@@ -76,7 +76,7 @@ module PayPal::SDK
       class CurrencyType < DataType
         def self.load_members
           object_of :code, String, :required => true
-          object_of :amount, Float, :required => true
+          object_of :amount, String, :required => true
         end
       end
 

--- a/spec/adaptive_payments_examples_spec.rb
+++ b/spec/adaptive_payments_examples_spec.rb
@@ -102,7 +102,7 @@ describe "AdaptivePayments" do
         :baseAmountList => {
           :currency => [{
             :code => "USD",
-            :amount => 2.0 }] },
+            :amount => "2.0" }] },
         :convertToCurrencyList => {
           :currencyCode => ["GBP"] } })
 

--- a/spec/convert_currency_spec.rb
+++ b/spec/convert_currency_spec.rb
@@ -16,7 +16,7 @@ describe "ConvertCurrency" do
   it "with request object" do
     convert_currency_request = @client.build_convert_currency()
     convert_currency_request.baseAmountList.currency[0].code   = "USD"
-    convert_currency_request.baseAmountList.currency[0].amount = 2.0
+    convert_currency_request.baseAmountList.currency[0].amount = "2.0"
     convert_currency_request.convertToCurrencyList.currencyCode = [ "GBP" ]
 
     response = @client.convert_currency(convert_currency_request)
@@ -27,13 +27,23 @@ describe "ConvertCurrency" do
     convert_currency_request = @client.build_convert_currency do
       baseAmountList do
         currency[0].code   = "USD"
-        currency[0].amount = 2.0
+        currency[0].amount = "2.0"
       end
       convertToCurrencyList.currencyCode = [ "GBP" ]
     end
 
     response = @client.convert_currency(convert_currency_request)
     response.response_envelope.ack.should eql "Success"
+  end
+
+  context "with a currency that does not use fractional units" do
+    it "succeeds" do
+      response = @client.convert_currency({
+        "baseAmountList"        => { "currency" => [{ "code" => "JPY", "amount" => "1" }] },
+        "convertToCurrencyList" => { "currencyCode" => ["USD"] }
+      })
+      response.response_envelope.ack.should eql "Success"
+    end
   end
 
 end


### PR DESCRIPTION
Fixes https://github.com/paypal/adaptivepayments-sdk-ruby/issues/15.